### PR TITLE
Fixing some implementation design  warnings (clock related)

### DIFF
--- a/adatTransmitter/Basys2_100_250General.ucf
+++ b/adatTransmitter/Basys2_100_250General.ucf
@@ -52,8 +52,8 @@ NET "mhz50_in" LOC = "B8"; # Bank = 0, Signal name = MCLK
 #NET "Led<4>" LOC = "N5" ;  # Bank = 2, Signal name = LD4
 #NET "Led<3>" LOC = "P6" ; # Bank = 2, Signal name = LD3
 #NET "Led<2>" LOC = "P7" ; # Bank = 3, Signal name = LD2
-NET "statesyncnot_led" LOC = "M11" ; # Bank = 2, Signal name = LD1
-NET "statesync_led" LOC = "M5" ;  # Bank = 2, Signal name = LD0
+#NET "statesyncnot_led" LOC = "M11" ; # Bank = 2, Signal name = LD1
+#NET "statesync_led" LOC = "M5" ;  # Bank = 2, Signal name = LD0
 
 # Pin assignment for SWs
 #NET "sw<7>" LOC = "N3";  # Bank = 2, Signal name = SW7

--- a/adatTransmitter/Basys2_100_250General.ucf
+++ b/adatTransmitter/Basys2_100_250General.ucf
@@ -4,10 +4,9 @@
 # - rename the used signals according to the project
 
 # clock pin for Basys2 Board
-#NET "mclk" LOC = "B8"; # Bank = 0, Signal name = MCLK
-NET "mclk_pin" LOC = "B8"; # Bank = 0, Signal name = MCLK
+NET "mhz50_in" LOC = "B8"; # Bank = 0, Signal name = MCLK
 #NET "uclk" LOC = "M6"; # Bank = 2, Signal name = UCLK
-NET "mclk_pin" CLOCK_DEDICATED_ROUTE = FALSE;
+#NET "mclk" CLOCK_DEDICATED_ROUTE = FALSE;
 #NET "mclk_pin" CLOCK_DEDICATED_ROUTE = TRUE;
 #NET "uclk" CLOCK_DEDICATED_ROUTE = FALSE;
 
@@ -90,22 +89,23 @@ NET "mclk_pin" CLOCK_DEDICATED_ROUTE = FALSE;
 #NET "OutBlue<1>"  LOC = "H13"  | DRIVE = 2  | PULLUP ; # Bank = 1, Signal name = BLU1 
 
 # Loop Back only tested signals
-NET "pdn_pin" LOC = "B2"  | IOSTANDARD = LVCMOS33 | DRIVE = 8; # Bank = 1, Signal name = JA1
-NET "tdm1_pin" LOC = "A3"  | IOSTANDARD = LVCMOS33 | DRIVE = 8; # Bank = 1, Signal name = JA2
-NET "tdm0_pin" LOC = "J3"  | IOSTANDARD = LVCMOS33 | DRIVE = 8; # Bank = 1, Signal name = JA3
-NET "msn_pin" LOC = "B5"  | IOSTANDARD = LVCMOS33 | DRIVE = 8; # Bank = 1, Signal name = JA4
+NET "pdn" LOC = "B2"  | IOSTANDARD = LVCMOS33 | DRIVE = 2; # Bank = 1, Signal name = JA1
+NET "tdm1" LOC = "A3"  | IOSTANDARD = LVCMOS33 | DRIVE = 2; # Bank = 1, Signal name = JA2
+NET "tdm0" LOC = "J3"  | IOSTANDARD = LVCMOS33 | DRIVE = 2; # Bank = 1, Signal name = JA3
+NET "msn" LOC = "B5"  | IOSTANDARD = LVCMOS33 | DRIVE = 2; # Bank = 1, Signal name = JA4
 
-NET "dif_pin" LOC = "C6"  | IOSTANDARD = LVCMOS33 | DRIVE = 8; # Bank = 1, Signal name = JB1
-NET "cks0_pin" LOC = "B6"  | IOSTANDARD = LVCMOS33 | DRIVE = 8; # Bank = 1, Signal name = JB2
-NET "cks1_pin" LOC = "C5"  | IOSTANDARD = LVCMOS33 | DRIVE = 8; # Bank = 1, Signal name = JB3
-NET "cks2_pin" LOC = "B7"  | IOSTANDARD = LVCMOS33 | DRIVE = 8; # Bank = 1, Signal name = JB4
+NET "dif" LOC = "C6"  | IOSTANDARD = LVCMOS33 | DRIVE = 2 ; # Bank = 1, Signal name = JB1
+NET "cks0" LOC = "B6"  | IOSTANDARD = LVCMOS33 | DRIVE = 2 ; # Bank = 1, Signal name = JB2
+NET "cks1" LOC = "C5"  | IOSTANDARD = LVCMOS33 | DRIVE = 2 ; # Bank = 1, Signal name = JB3
+NET "mclk" LOC = "B7"  | IOSTANDARD = LVCMOS33 | DRIVE = 2 ; # Bank = 1, Signal name = JB4
 
-NET "hpfe_pin" LOC = "A9"  | IOSTANDARD = LVCMOS33 | DRIVE = 8; # Bank = 1, Signal name = JC1
-NET "mono_pin" LOC = "B9"  | IOSTANDARD = LVCMOS33 | DRIVE = 8; # Bank = 1, Signal name = JC2
-#NET "ovf_pin" LOC = "A10" | IOSTANDARD = LVCMOS33 | DRIVE = 8 | PULLUP ; # Bank = 1, Signal name = JC3
-NET "sdto1_pin" LOC = "C9"  | IOSTANDARD = LVCMOS33 | DRIVE = 8 | PULLUP ; # Bank = 1, Signal name = JC4
+NET "mhz50_out" LOC = "A9" | IOSTANDARD = LVCMOS33 | DRIVE = 2 ; # Bank = 1, Signal name = JC1
+NET "bick" LOC = "B9"  | IOSTANDARD = LVCMOS33 | DRIVE = 2 ; # Bank = 1, Signal name = JC2
+NET "lrck" LOC = "A10" | IOSTANDARD = LVCMOS33 | DRIVE = 2 ; # Bank = 1, Signal name = JC3
+NET "mclk_out" LOC = "C9" | IOSTANDARD = LVCMOS33 | DRIVE = 2 ; # Bank = 1, Signal name = JC4
 
-#NET "mclk_pin" LOC = "C12"  | IOSTANDARD = LVCMOS33 | DRIVE = 8  | PULLUP ; # Bank = 1, Signal name = JD1
-NET "bick_pin" LOC = "A13"  | IOSTANDARD = LVCMOS33 | DRIVE = 8 ; # Bank = 2, Signal name = JD2
-NET "lrck_pin" LOC = "C13"  | IOSTANDARD = LVCMOS33 | DRIVE = 8 ; # Bank = 1, Signal name = JD3
-NET "transmit_pin" LOC = "D12"  | IOSTANDARD = LVCMOS33 | DRIVE = 8 ; # Bank = 2, Signal name = JD4
+NET "cks2" LOC = "C12"  | IOSTANDARD = LVCMOS33 | DRIVE = 2 ; # Bank = 1, Signal name = JD1
+NET "hpfe" LOC = "A13"  | IOSTANDARD = LVCMOS33 | DRIVE = 2 ; # Bank = 2, Signal name = JD2
+NET "sdto1" LOC = "C13"  | IOSTANDARD = LVCMOS33 | DRIVE = 2 ; # Bank = 1, Signal name = JD3
+NET "transmit" LOC = "D12"  | IOSTANDARD = LVCMOS33 | DRIVE = 2 ; # Bank = 2, Signal name = JD4
+#NET "ovf_pin" LOC = "D12"  | IOSTANDARD = LVCMOS33 | DRIVE = 8 ; # Bank = 2, Signal name = JD4

--- a/adatTransmitter/Basys2_100_250General.ucf
+++ b/adatTransmitter/Basys2_100_250General.ucf
@@ -5,8 +5,10 @@
 
 # clock pin for Basys2 Board
 #NET "mclk" LOC = "B8"; # Bank = 0, Signal name = MCLK
+NET "mclk_pin" LOC = "B8"; # Bank = 0, Signal name = MCLK
 #NET "uclk" LOC = "M6"; # Bank = 2, Signal name = UCLK
 NET "mclk_pin" CLOCK_DEDICATED_ROUTE = FALSE;
+#NET "mclk_pin" CLOCK_DEDICATED_ROUTE = TRUE;
 #NET "uclk" CLOCK_DEDICATED_ROUTE = FALSE;
 
 # Pin assignment for EppCtl
@@ -103,7 +105,7 @@ NET "lrck_pin" LOC = "B9"  | IOSTANDARD = LVCMOS25 | DRIVE = 8; # Bank = 1, Sign
 NET "sdto1_pin" LOC = "A10" | IOSTANDARD = LVCMOS25 | DRIVE = 8  | PULLUP ; # Bank = 1, Signal name = JC3
 NET "transmit_pin" LOC = "C9"  | IOSTANDARD = LVCMOS25 | DRIVE = 8; # Bank = 1, Signal name = JC4
 
-NET "mclk_pin" LOC = "C12"  | IOSTANDARD = LVCMOS25 | DRIVE = 8  | PULLUP ; # Bank = 1, Signal name = JD1
+#NET "mclk_pin" LOC = "C12"  | IOSTANDARD = LVCMOS25 | DRIVE = 8  | PULLUP ; # Bank = 1, Signal name = JD1
 #NET "PIO<85>" LOC = "A13"  | DRIVE = 2  | PULLUP ; # Bank = 2, Signal name = JD2
 #NET "PIO<86>" LOC = "C13"  | DRIVE = 2  | PULLUP ; # Bank = 1, Signal name = JD3
 #NET "PIO<87>" LOC = "D12"  | DRIVE = 2  | PULLUP ; # Bank = 2, Signal name = JD4 

--- a/adatTransmitter/Basys2_100_250General.ucf
+++ b/adatTransmitter/Basys2_100_250General.ucf
@@ -52,8 +52,8 @@ NET "mhz50_in" LOC = "B8"; # Bank = 0, Signal name = MCLK
 #NET "Led<4>" LOC = "N5" ;  # Bank = 2, Signal name = LD4
 #NET "Led<3>" LOC = "P6" ; # Bank = 2, Signal name = LD3
 #NET "Led<2>" LOC = "P7" ; # Bank = 3, Signal name = LD2
-#NET "Led<1>" LOC = "M11" ; # Bank = 2, Signal name = LD1
-#NET "Led<0>" LOC = "M5" ;  # Bank = 2, Signal name = LD0
+NET "statesyncnot_led" LOC = "M11" ; # Bank = 2, Signal name = LD1
+NET "statesync_led" LOC = "M5" ;  # Bank = 2, Signal name = LD0
 
 # Pin assignment for SWs
 #NET "sw<7>" LOC = "N3";  # Bank = 2, Signal name = SW7

--- a/adatTransmitter/adatmitter.vhd
+++ b/adatTransmitter/adatmitter.vhd
@@ -52,10 +52,10 @@ entity adatmitter is
 		cks2 : out std_logic;
 		transmit: out std_logic;
 		hpfe : out std_logic;
-		mono : out std_logic;
+		mono : out std_logic
 		
-		statesync_led : out std_logic;
-		statesyncnot_led : out std_logic
+--		statesync_led : out std_logic;
+--		statesyncnot_led : out std_logic
 	);	
 end adatmitter;
 
@@ -93,8 +93,8 @@ architecture adatmitter_arch of adatmitter is
 	signal fs_counter : unsigned(7 downto 0) := "00000000";
 	
 	--sync leds
-	signal statesyncled_send : std_logic;
-	signal statesyncled_read : std_logic;
+--	signal statesyncled_send : std_logic;
+--	signal statesyncled_read : std_logic;
 
 begin	
 	dif <= '0';
@@ -149,18 +149,18 @@ begin
 	end process;
 	
 	--state sync led to make sure read and send are synced
-	process(mclk)
-	begin
-		if (mclk'event and mclk='0') then
-			if (statesyncled_send='1') then
-				if (statesyncled_read='1') then
-					statesync_led <= '1';
-				else 
-					statesyncnot_led <= '1';
-				end if;
-			end if;
-		end if;
-	end process;
+--	process(mclk)
+--	begin
+--		if (mclk'event and mclk='0') then
+--			if (statesyncled_send='1') then
+--				if (statesyncled_read='1') then
+--					statesync_led <= '1';
+--				else 
+--					statesyncnot_led <= '1';
+--				end if;
+--			end if;
+--		end if;
+--	end process;
 	
 	-- next-state logic
 	process (state_reg_read, read_counter, state_reg_send, send_counter, ss5_counter, integrity_counter, ch1_reg, ch2_reg, ch3_reg, ch4_reg, sdto1)
@@ -197,7 +197,7 @@ begin
 				elsif (read_counter=24) then
 					state_next_send <= send1;
 					send_counter_next <= (others => '0');
-					statesyncled_read <= '1';
+--					statesyncled_read <= '1';
 				elsif (read_counter=31) then
 					state_next_read <= read2;
 					read_counter_next <= (others => '0');
@@ -290,7 +290,7 @@ begin
 					ch5678s_next <= '1';
 				elsif (send_counter=15) then
 					send_counter_next <= (others => '0');
-					statesyncled_send <='1';
+--					statesyncled_send <='1';
 				end if;
 		end case;
 	end process;

--- a/adatTransmitter/adatmitter.vhd
+++ b/adatTransmitter/adatmitter.vhd
@@ -126,8 +126,9 @@ architecture adatmitter_arch of adatmitter is
 	signal tdm0 : std_logic := '0';
 
 begin
-	mclk_ibufg_inst : IBUFG port map (I => mclk_pin, O => mclk_ibufg);
-	mclk_bufg_inst : BUFG port map (I => mclk_ibufg, O => mclk);
+	--mclk_ibufg_inst : IBUFG port map (I => mclk_pin, O => mclk_ibufg);
+	--mclk_bufg_inst : BUFG port map (I => mclk_ibufg, O => mclk);
+	mclk_ibufg_inst : IBUFG port map (I => mclk_pin, O => mclk);
 	
 	sdto1_inst : IBUF port map (I => sdto1_pin, O => sdto1);
 	


### PR DESCRIPTION
This fixes the clock skew warnings
Documents of interest: 
https://reference.digilentinc.com/_media/basys2:basys2_rm.pdf (pg. 3)
https://www.xilinx.com/support/documentation/user_guides/ug331.pdf (pg. 50)

Changes:
1. Moved the clock signal back to LOC "B8" (this should be a input on the board that you can switch between the built in oscillator or connect to an external/off board input).
2. Removed the double buffer of the clock input signal

